### PR TITLE
Fix bug when splunk server is in a bad state / restarting

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,11 @@ var SplunkStream = function (config) {
     // Overwrite the common library's error callback
     var that = this;
     this.logger.error = function(err, context) {
-        that.emit("error", err, context);
+        try{
+            that.emit("error", err, context);
+        }catch(e){
+            //continue...   
+        }
     };
 
     /* jshint unused:false */


### PR DESCRIPTION
Without this try catch block on the error handler, you will cause an 'Error: socket hang up' exception and crash the application.