### PR TITLE
Hotfix/crash on bad hechost

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,11 @@ var SplunkStream = function (config) {
     // Overwrite the common library's error callback
     var that = this;
     this.logger.error = function(err, context) {
-        that.emit("error", err, context);
+        try {
+            that.emit("error", err, context);
+        } catch(e) {
+            console.log(e);
+        }
     };
 
     /* jshint unused:false */


### PR DESCRIPTION
We found the splunk-bunyan-logger will throw and crash the whole web service when the hec host name is not resolvable or not available.  I tried the test with package but it has error. However this issue can be easily repeated and the fix is obvious.  The basic idea is don't throw up but catch print the error to console.  Please review it. Thank you.